### PR TITLE
Proximity explanation

### DIFF
--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -161,7 +161,7 @@ Like in {{RFC8955}}, proximity shown by making TLS connections between the Pledg
 The TLS connection is used to make a Voucher Request.
 This request is verified by the an agent of the Pledge's manufacturer, which then issues a voucher.
 The voucher provides an authorization statement from the manufacturer indicating that the Registrar is the intended owner of the device.
-The voucher refers to the Registrar through pinning of the Registrar's key.
+The voucher refers to the Registrar through pinning of the Registrar's identity.
 
 This document does not make any extensions to the semantic meaning of vouchers, only the encoding has been changed to optimize for constrained devices and networks.
 The two main parts of the BRSKI protocol are named separately in this document: BRSKI-EST for the protocol between Pledge and Registrar, and BRSKI-MASA for the

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -160,7 +160,7 @@ The two main parts of the BRSKI protocol are named separately in this document: 
 protocol between the Registrar and the MASA.
 
 Time-based vouchers are supported in this definition, but given that constrained devices are extremely unlikely to have accurate time, their use will be uncommon.
-Most Pledges using these constrained vouchers will be online during enrollment and will use live nonces to provide anti-replay protection rather than expiry times.
+Most Pledges using constrained vouchers will be online during enrollment and will use live nonces to provide anti-replay protection rather than expiry times.
 
 {{RFC8366}} defines the voucher artifact, while the Voucher Request artifact was defined in {{RFC8995}}.
 This document defines both a constrained voucher and a constrained voucher-request.

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -161,6 +161,7 @@ Like in {{RFC8955}}, proximity shown by making TLS connections between the Pledg
 The TLS connection is used to make a Voucher Request.
 This request is verified by the an agent of the Pledge's manufacturer, which then issues a voucher.
 The voucher provides an authorization statement from the manufacturer indicating that the Registrar is the intended owner of the device.
+The voucher refers to the Registrar through pinning of the Registrar's key.
 
 This document does not make any extensions to the semantic meaning of vouchers, only the encoding has been changed to optimize for constrained devices and networks.
 The two main parts of the BRSKI protocol are named separately in this document: BRSKI-EST for the protocol between Pledge and Registrar, and BRSKI-MASA for the

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -155,6 +155,13 @@ The term Registrar Voucher Request, or acronym RVR, is introduced to refer to th
 
 {{RFC8366}} provides for vouchers that assert proximity, that authenticate the Registrar and that can offer varying levels of anti-replay protection.
 
+The proximity proof provided for in {{RFC8366}}, is an assertion that the Pledge and the Registrar are believed to be in close together, from a network topology point of view.
+Like in {{RFC8955}}, proximity shown by making TLS connections between the Pledge and Registrar using IPv6 Link-Local addresses.
+
+The TLS connection is used to make a Voucher Request.
+This request is verified by the an agent of the Pledge's manufacturer, which then issues a voucher.
+The voucher provides an authorization statement from the manufacturer indicating that the Registrar is the intended owner of the device.
+
 This document does not make any extensions to the semantic meaning of vouchers, only the encoding has been changed to optimize for constrained devices and networks.
 The two main parts of the BRSKI protocol are named separately in this document: BRSKI-EST for the protocol between Pledge and Registrar, and BRSKI-MASA for the
 protocol between the Registrar and the MASA.


### PR DESCRIPTION
add explanation of proximity, remove errant word "these", and recap RFC8995 protocol.
close #134 