### PR TITLE
clarification of RFC4210 Root CA key change, close #163

### DIFF
--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -450,11 +450,21 @@ This section defines extensions to EST-coaps clients, used after the BRSKI boots
 A constrained EST-coaps client MAY support only the Content-Format TBD287 ("application/pkix-cert") in a /crts response, per {{Section 5.3 of I-D.ietf-ace-coap-est}}.
 
 In this case, it can only store one trust anchor of the domain. Although this is not an issue in case the domain trust anchor remains stable, special consideration is
-needed for cases where the domain trust anchor can change over time.
-The mechanism described in {{RFC4210, Section 4.4}} allows for a new CA to sign the old CA, so even during rollover of trust anchors, it is possible to have only a single trust anchor.
-Such a change may happen during EST re-enrollment: typically, a change of domain CA requires all devices
+needed for cases where the domain trust anchor can change over time. Such a change may happen due to relocation of the client device to a new domain, or due to key update of
+the trust anchor as described in {{RFC4210, Section 4.4}}.  
+
+The trust anchor change may happen during EST re-enrollment: typically, a change of domain CA requires all devices
 operating under the old domain CA to acquire a new LDevID issued by the new domain CA. A client's re-enrollment may be triggered by various events, such as imminent expiry of its LDevID.
 How the re-enrollment is explicitly triggered on the client by a domain entity, such as a commissioner or a Registrar, is out of scope of this specification.
+
+The mechanism described in {{RFC4210, Section 4.4}} for Root CA key update requires four certificates: OldWithOld, OldWithNew, NewWithOld, and NewWithNew. The OldWithOld certificate is already
+stored in the EST client's trust store. The NewWithNew certificate will be distributed as the single certificate in a /crts response, during EST re-enrollment. 
+Since the EST client can only accept a single certificate in a /crts response it implies that the EST client 
+cannot obtain the certificates OldWithNew and NewWithOld in this way, to perform the complete verification of the new domain CA. Instead, the client only verifies the EST server (Registrar) using its 
+old domain CA certificate in its trust store as detailed below, and based on this trust in the active and valid DTLS connection it automatically trusts the 
+new (NewWithNew) domain CA certificate that the EST server provides in the /crts response.
+
+In this manner, even during rollover of trust anchors, it is possible to have only a single trust anchor provided in a /crts response.
 
 For re-enrollment, the constrained EST-coaps client MUST support the following EST-coaps procedure, where optional re-enrollment to a new domain is under control of the Registrar:
 


### PR DESCRIPTION
New text to detail how CA key change could be done. I don't think the full RFC4210 Section 4.4 process can work in our case, hence this simplified proposal.

People may see security issues here; I don't see one to be honest... 

PS An alternative  simpler solution could be to just forbid Domain CA key change or Domain CA relocation -> you just have to redo the BRSKI bootstrap in such case, so the MASA again may have a say if it likes the new domain or not.