### PR TITLE
Update cert scripts to the actually used scripts for examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,17 @@ CWTSIDLIST1=ietf-voucher-constrained-sid.txt
 CWTDATE2=yang/ietf-voucher-request-constrained@${YANGDATE}.yang
 CWTSIDLIST2=ietf-voucher-request-constrained-sid.txt
 CWTSIDDATE2=ietf-voucher-request-constrained@${YANGDATE}.sid
-EXAMPLES=examples/cms-parboiled-request.b64
-EXAMPLES+=examples/voucher-example1.txt
-EXAMPLES+=examples/voucher-request-example1.txt
+EXAMPLES=two-ca-chain.txt
+EXAMPLES+=pinning-options.txt
+EXAMPLES+=$(wildcard examples/voucher-example*.txt)
+EXAMPLES+=$(wildcard examples/voucher-request-example*.txt)
 EXAMPLES+=examples/voucher-status.hex
 EXAMPLES+=examples/voucher-statusdiag.txt
-EXAMPLES+=examples/vr_00-D0-E5-F2-00-03.b64
-EXAMPLES+=examples/vr_00-D0-E5-F2-00-03.diag
-EXAMPLES+=examples/cose-examples/*.*
+EXAMPLES+=$(wildcard examples/cose-examples/*.txt)
+EXAMPLES+=$(wildcard examples/cose-examples/*.hex)
+EXAMPLES+=$(wildcard examples/script-cose-examples/*.sh)
+EXAMPLES+=$(wildcard examples/script-cose-examples/*.ext)
+EXAMPLES+=$(wildcard examples/cose-examples/keys/*.pem)
 PYANG=./pyang.sh
 PYANGPATH=--path=../../anima/bootstrap/yang --path ${HOME}/.local/share/yang/modules/ietf
 

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -1863,13 +1863,16 @@ shown in {{cose-example-domain-ca-cert}}.
 
 # Generating Certificates with OpenSSL {#appendix-gencerts}
 
-This informative appendix shows an example of a Bash shell script to generate test certificates for the Pledge IDevID, the Registrar and the MASA.
-This shell script cannot be run stand-alone because it depends on particular input files which are not included in this appendix. Nevertheless,
-this example script may provide guidance on how OpenSSL can be configured for generating Constrained BRSKI certificates.
+This informative appendix shows example Bash shell scripts to generate test certificates for the Pledge IDevID, the Registrar and the MASA.
+The shell scripts cannot be run stand-alone because they depend on input files which are not all included in this appendix. Nevertheless,
+these scripts may provide guidance on how OpenSSL can be configured for generating Constrained BRSKI certificates.
 
-Note: the *-comb.crt certificate files combine the certificate with the private key. These are generated to be used by libcoap for DTLS connection establishment.
+The scripts were tested with OpenSSL 3.0.2. Older versions may not work -- OpenSSL 1.1.1 for example does not support all extensions used.
 
-INSERT_CODE_FROM_FILE examples/brski-cert.sh END
+INSERT_CODE_FROM_FILE examples/script-cose-examples/create-cert-Pledge.sh END
+INSERT_CODE_FROM_FILE examples/script-cose-examples/x509v3.ext END
+INSERT_CODE_FROM_FILE examples/script-cose-examples/create-cert-Registrar.sh END
+INSERT_CODE_FROM_FILE examples/script-cose-examples/create-cert-MASA.sh END
 
 
 # Pledge Device Class Profiles {#appendix-pledge-profiles}

--- a/examples/script-cose-examples/create-cert-MASA.sh
+++ b/examples/script-cose-examples/create-cert-MASA.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# File: create-cert-MASA.sh
 # Create new cert for: MASA CA, self-signed CA certificate
 
 # days certificate is valid
@@ -7,14 +8,19 @@ VALIDITY=3650
 NAME=masa_ca
 
 # create csr
-openssl req -new -key keys/privkey_masa_ca.pem -out $NAME.csr -subj "/CN=masa.stok.nl/O=vanderstok/L=Helmond/C=NL"
+openssl req -new -key keys/privkey_masa_ca.pem -out $NAME.csr \
+            -subj "/CN=masa.stok.nl/O=vanderstok/L=Helmond/C=NL"
 
 # sign csr
 mkdir output >& /dev/null
-openssl x509 -set_serial 0xE39CDA17E1386A0A  -extfile x509v3.ext -extensions masa_ca_ext -req -in $NAME.csr -signkey keys/privkey_masa_ca.pem -out output/$NAME.pem -days $VALIDITY -sha256
+openssl x509 -set_serial 0xE39CDA17E1386A0A  -extfile x509v3.ext \
+ -extensions masa_ca_ext -req -in $NAME.csr \
+ -signkey keys/privkey_masa_ca.pem -out output/$NAME.pem \
+ -days $VALIDITY -sha256
 
 # delete temp files
 rm -f $NAME.csr
 
 # convert to .der format
-openssl x509 -in output/$NAME.pem -inform PEM -out output/$NAME.der -outform DER
+openssl x509 -in output/$NAME.pem -inform PEM -out output/$NAME.der \
+             -outform DER

--- a/examples/script-cose-examples/create-cert-Pledge.sh
+++ b/examples/script-cose-examples/create-cert-Pledge.sh
@@ -1,25 +1,32 @@
 #!/bin/bash
+# File: create-cert-Pledge.sh
 # Create new cert for: Pledge IDevID
 
-# days certificate is valid - try to get close to the 802.1AR specified 9999-12-31 end date.
+# days certificate is valid - try to get close to the 802.1AR 
+# specified 9999-12-31 end date.
 SECONDS1=`date +%s` # time now
-SECONDS2=`date --date="9999-12-31 23:59:59Z" +%s`   # target end time
+SECONDS2=`date --date="9999-12-31 23:59:59Z" +%s` # target end time
 let VALIDITY="(${SECONDS2}-${SECONDS1})/(24*3600)"
 echo "Using validity param -days ${VALIDITY}"
 
 NAME=pledge
 
 # create csr for device
-# conform to 802.1AR guidelines, using only CN + serialNumber when manufacturer is already present as CA.
+# conform to 802.1AR guidelines, using only CN + serialNumber when 
+# manufacturer is already present as CA.
 # CN is not even mandatory, but just good practice.
-openssl req -new -key keys/privkey_pledge.pem -out $NAME.csr -subj "/CN=Stok IoT sensor Y-42/serialNumber=JADA123456789"
+openssl req -new -key keys/privkey_pledge.pem -out $NAME.csr -subj \
+             "/CN=Stok IoT sensor Y-42/serialNumber=JADA123456789"
 
 # sign csr
-openssl x509 -set_serial 32429 -CAform PEM -CA output/masa_ca.pem -CAkey keys/privkey_masa_ca.pem -extfile x509v3.ext -extensions pledge_ext -req -in $NAME.csr -out output/$NAME.pem -days $VALIDITY -sha256
+openssl x509 -set_serial 32429 -CAform PEM -CA output/masa_ca.pem \
+  -CAkey keys/privkey_masa_ca.pem -extfile x509v3.ext -extensions \
+  pledge_ext -req -in $NAME.csr -out output/$NAME.pem \
+  -days $VALIDITY -sha256
 
 # delete temp files
 rm -f $NAME.csr
 
 # convert to .der format
-openssl x509 -in output/$NAME.pem -inform PEM -out output/$NAME.der -outform DER
-
+openssl x509 -in output/$NAME.pem -inform PEM -out output/$NAME.der \
+             -outform DER

--- a/examples/script-cose-examples/create-cert-Registrar.sh
+++ b/examples/script-cose-examples/create-cert-Registrar.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# File: create-cert-Registrar.sh
 # Create new cert for: Registrar in a company domain
 
 # days certificate is valid
@@ -8,14 +9,19 @@ VALIDITY=1095
 NAME=registrar
 
 # create csr
-openssl req -new -key keys/privkey_registrar.pem -out $NAME.csr -subj "/CN=Custom-ER Registrar/OU=Office dept/O=Custom-ER, Inc./L=Ottowa/ST=ON/C=CA"
+openssl req -new -key keys/privkey_registrar.pem -out $NAME.csr \
+ -subj "/CN=Custom-ER Registrar/OU=Office dept/O=Custom-ER, Inc./\
+ L=Ottowa/ST=ON/C=CA"
 
 # sign csr
-openssl x509 -set_serial 0xC3F62149B2E30E3E -CAform PEM -CA output/domain_ca.pem -extfile x509v3.ext -extensions registrar_ext -req -in $NAME.csr -CAkey keys/privkey_domain_ca.pem -out output/$NAME.pem -days $VALIDITY -sha256
+openssl x509 -set_serial 0xC3F62149B2E30E3E -CAform PEM -CA \
+ output/domain_ca.pem -extfile x509v3.ext -extensions registrar_ext \
+ -req -in $NAME.csr -CAkey keys/privkey_domain_ca.pem \
+ -out output/$NAME.pem -days $VALIDITY -sha256
 
 # delete temp files
 rm -f $NAME.csr
 
 # convert to .der format
-openssl x509 -in output/$NAME.pem -inform PEM -out output/$NAME.der -outform DER
-
+openssl x509 -in output/$NAME.pem -inform PEM -out output/$NAME.der \
+             -outform DER

--- a/examples/script-cose-examples/create-cert-Registrar.sh
+++ b/examples/script-cose-examples/create-cert-Registrar.sh
@@ -11,7 +11,7 @@ NAME=registrar
 # create csr
 openssl req -new -key keys/privkey_registrar.pem -out $NAME.csr \
  -subj "/CN=Custom-ER Registrar/OU=Office dept/O=Custom-ER, Inc./\
- L=Ottowa/ST=ON/C=CA"
+L=Ottowa/ST=ON/C=CA"
 
 # sign csr
 openssl x509 -set_serial 0xC3F62149B2E30E3E -CAform PEM -CA \

--- a/examples/script-cose-examples/x509v3.ext
+++ b/examples/script-cose-examples/x509v3.ext
@@ -1,6 +1,7 @@
-#
-# This file contains all X509v3 extension definitions for OpenSSL certificate generation.
-# Each certificate has its own _ext section below.
+# File: x509v3.ext
+# This file contains all X509v3 extension definitions for OpenSSL
+# certificate generation. Each certificate has its own _ext 
+# section below.
 
 [ req ]
 prompt = no
@@ -13,8 +14,10 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid
 
 [ pledge_ext ]
-keyUsage = critical,digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-# basicConstraints for a non-CA cert MAY be marked either non-critical or critical.
+keyUsage = critical,digitalSignature, nonRepudiation, \
+           keyEncipherment, dataEncipherment
+# basicConstraints for a non-CA cert MAY be marked either 
+# non-critical or critical.
 basicConstraints = CA:FALSE
 # Don't include subjectKeyIdentifier (SKI) - see 802.1AR-2018
 subjectKeyIdentifier = none
@@ -26,16 +29,19 @@ authorityKeyIdentifier=keyid
 subjectAltName=email:help@custom-er.example.com
 keyUsage = critical, keyCertSign, digitalSignature, cRLSign
 basicConstraints=critical,CA:TRUE
-# RFC 5280 4.2.1.1 : AKI MAY be omitted, and MUST be non-critical ; SKI MUST be non-critical
+# RFC 5280 4.2.1.1 : AKI MAY be omitted, and MUST be non-critical; 
+# SKI MUST be non-critical
 subjectKeyIdentifier=hash
 
 [ registrar_ext ]
-keyUsage = critical, digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+keyUsage = critical, digitalSignature, nonRepudiation, \
+           keyEncipherment, dataEncipherment
 basicConstraints=CA:FALSE
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid
 # Set Registrar 'RA' flag along with TLS client/server usage
-#  see https://datatracker.ietf.org/doc/html/draft-ietf-anima-constrained-voucher#section-7.3
-#  see https://tools.ietf.org/html/rfc6402#section-2.10
-#  see https://www.openssl.org/docs/man1.1.1/man5/x509v3_config.html
-extendedKeyUsage = critical,1.3.6.1.5.5.7.3.28, serverAuth, clientAuth
+#  see draft-ietf-anima-constrained-voucher#section-7.3
+#  see tools.ietf.org/html/rfc6402#section-2.10
+#  see www.openssl.org/docs/man1.1.1/man5/x509v3_config.html
+extendedKeyUsage = critical,1.3.6.1.5.5.7.3.28, serverAuth, \
+                   clientAuth


### PR DESCRIPTION
This includes the scripts to generate certificates; and the all-important X.509v3 extensions file that's used by the scripts.
The Makefile is updated to point to correct example files.