### PR TITLE
Remove Updates for RFC 8366, use 8366bis only; move 8366 to Informative refs

### DIFF
--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -12,7 +12,7 @@ kw: Internet-Draft
 cat: std
 stream: IETF
 consensus: true
-updates: 8366, 8995
+updates: 8995
 
 pi:    # can use array (if all yes) or hash here
   toc: yes
@@ -54,7 +54,6 @@ normative:
   RFC7250:
   RFC7252:
   RFC7950:
-  RFC8366:
   RFC8366bis: I-D.ietf-anima-rfc8366bis
   RFC8446:
   RFC8449:
@@ -82,6 +81,7 @@ informative:
   RFC6838:
   RFC7030:
   RFC7228:
+  RFC8366:
   RFC8990:
   RFC9053:
   I-D.ietf-core-sid:
@@ -120,7 +120,7 @@ While the BRSKI voucher data is encoded in JSON, cBRSKI uses a compact CBOR-enco
 The BRSKI voucher data definition is extended with new data types that allow for smaller voucher sizes.
 The Enrollment over Secure Transport (EST) protocol, used in BRSKI, is replaced with EST-over-CoAPS;
 and HTTPS used in BRSKI is replaced with DTLS-secured CoAP (CoAPS).
-This document Updates RFC 8366 and RFC 8995.
+This document Updates RFC 8995.
 
 --- middle
 
@@ -137,9 +137,9 @@ Using the IDevID the pledges are securely enrolled into a network.
 
 The BRSKI solution described in {{RFC8995}} was designed to be modular, and this document describes a version scaled to the constraints of IoT deployments.
 
-Therefore, this document uses constrained versions of the voucher artifact and voucher request artifact as described in {{RFC8366bis}}, along with a constrained 
-version of the BRSKI protocol.
-This cBRSKI protocol makes use of the CoAP-based version of EST (EST-coaps from {{RFC9148}}) rather than the EST over HTTPS {{RFC7030}}. 
+Therefore, this document uses the constrained voucher artifact and voucher request artifact defined in {{RFC8366bis}} and specifies a constrained 
+version of the BRSKI protocol: cBRSKI.
+The cBRSKI protocol uses the CoAP-based version of EST (EST-coaps from {{RFC9148}}) rather than the EST over HTTPS {{RFC7030}}. 
 cBRSKI is itself scalable to multiple resource levels through the definition of optional functions. {{appendix-pledge-profiles}} illustrates this.
 
 In BRSKI, the {{RFC8366}} voucher data is by default serialized to JSON with a signature in CMS {{RFC5652}}.
@@ -224,26 +224,24 @@ The MASA therefore knows if the Pledge supports PKIX operations, or if it is lim
 Based upon this, the MASA can select which attributes to use in the voucher data for certain operations, like the pinning of the Registrar or domain identity.
 
 
-# Updates to {{RFC8366bis}} and RFC8995
+# Updates to RFC 8995
 
 This section details the ways in which this document updates other RFCs.
-The terminology for Updates is taken from {{I-D.kuehlewind-update-tag}}.
+The terminology for Updates, Amends and Extends is taken from {{I-D.kuehlewind-update-tag}}.
 
-This document Updates {{RFC8366bis}}. It Extends {{RFC8366bis}} with a COSE signature format, and new mechanisms to identify Registrar proximity and to pin a Raw Public Key (RPK).
+This document Updates {{RFC8995}}. It Amends {{RFC8995}} because it:
 
-This document Updates {{RFC8995}}. It Amends {{RFC8995}}
+* clarifies how pinning in vouchers is done ({{pinning}}),
 
-* by clarifying how pinning is done,
+* adopts clearer explanation of the TLS Server Name Indicator (SNI) in {{sni}} and {{sni-masa}},
 
-* adopts clearer explanation of the TLS Server Name Indicator (SNI), see {{sni}} and {{sni-masa}},
-
-* clarifies when new trust anchors should be retrieved ({{brski-est-extensions-pledge}}),
+* clarifies when new trust anchors should be retrieved by a Pledge ({{brski-est-extensions-pledge}}),
 
 * clarifies what kinds of Extended Key Usage attributes are appropriate for each certificate ({{registrar-certificate-requirement-server}}, {{registrar-certificate-requirement-client}}).
 
 It Extends {{RFC8995}} as follows:
 
-* defines the use of CoAP with the BRSKI protocol,
+* defines the use of CoAP for the BRSKI protocol,
 
 * makes some messages optional if the results can be inferred from other validations ({{brski-est-extensions}}),
 


### PR DESCRIPTION
Close #285