### PR TITLE
security: add DTLS 1.2 and 1.3 cipher suite details

### DIFF
--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -270,7 +270,8 @@ This document Updates {{RFC8995}} because it adds normative requirements on:
 
 This document Updates {{RFC9148}} because it:
 
-* defines stricter DTLS requirements ({{brski-est-dtls}})),
+* defines stricter DTLS requirements ({{brski-est-dtls}})), including mandatory DTLS 1.3 cipher suites
+  ({{dtls-ciphersuites}}),
 
 * normatively details how an EST-coaps client handles certificate renewal and re-enrollment ({{brski-est-extensions}}),
 
@@ -293,7 +294,7 @@ This section describes the extensions to both BRSKI {{RFC8995}} and EST-coaps {{
 A DTLS connection is established between the Pledge and the Registrar, similar to the TLS connection
 described in {{Section 5.1 of RFC8995}}. This may occur via a Join Proxy as described in {{joinproxy}}.
 Regardless of the Join Proxy presence or particular mechanism used, the DTLS connection should operate identically.
-The cBRSKI and EST-coaps requests and responses for onboarding are carried over this DTLS connection.
+The cBRSKI and EST-coaps CoAP requests and responses for onboarding are carried over this DTLS connection.
 
 ### DTLS Version {#dtls-version}
 
@@ -302,8 +303,55 @@ be used is in a Pledge that uses a software platform where a DTLS 1.3 client is 
 device gets software-upgraded to support cBRSKI. For this reason, a Registrar MUST by default support both DTLS 1.3 and DTLS 1.2
 client connections. However, for security reasons the Registrar MAY be administratively configured to support only a particular DTLS version or higher.
 
-An EST-coaps server {{RFC9148}} (if present as a separate entity from above Registrar) that implements this specification also MUST support both DTLS 1.3 and DTLS 1.2 client connections by default.
-However, for security reasons the EST-coaps server MAY be administratively configured to support only a particular DTLS version or higher.
+A Pledge that implements DTLS 1.3 MUST NOT additionally implement DTLS 1.2.
+This prevents a rogue Registrar from forcing the Pledge onto DTLS 1.2, reduces the DTLS code and attack surface on the
+constrained Pledge, and keeps more handshake metadata encrypted.
+
+An EST-coaps server {{RFC9148}}, if present as a separate CoAP endpoint from above Registrar, that implements this specification
+also MUST support both DTLS 1.3 and DTLS 1.2 client connections by default.
+Again, for security reasons the EST-coaps server MAY be administratively configured to support only a particular DTLS version or higher.
+
+### DTLS Cipher Suites {#dtls-ciphersuites}
+
+#### DTLS 1.2 Cipher Suites
+
+The DTLS 1.2 cipher suite requirements of {{Section 3 of RFC9148}} MUST be applied to a Registrar and, if present, an EST-coaps
+server hosted at a separate endpoint.
+These requirements include mandatory support for TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8.
+This is the default CoAPS cipher suite as specified in {{Section 9.1.3.3 of RFC7252}}.
+
+A Pledge using DTLS 1.2 MUST implement the above cipher suite and MAY implement others.
+
+#### DTLS 1.3 Cipher Suites
+
+The DTLS 1.3 requirements of {{Section 3 of RFC9148}} MUST be applied to a Registrar and, if present, an EST-coaps
+server hosted at a separate endpoint.
+However, these do not include a specific cipher suite requirement.
+
+This document updates {{RFC9148}} by defining the DTLS 1.3 mandatory cipher suites for an EST-coaps server.
+A Registrar and, if present, a separate EST-coaps server, MUST support the following cipher suites:
+
+* mandatory TLS 1.3 cipher suites as defined in {{Section 9.1 of RFC8446}} (TLS_AES_128_GCM_SHA256 with the digital
+  signature and key exchange algorithms listed there)
+* TLS_AES_128_CCM_8_SHA256 (with the same digital signature and key exchange algorithms)
+* TLS_AES_128_CCM_SHA256 (with the same digital signature and key exchange algorithms)
+
+A Pledge whose IDevID certificate contains an Ed25519 public key (as recommended for new designs in {{VR-COSE}}) uses
+the same Ed25519 IDevID private key to sign the DTLS handshake CertificateVerify and to sign its PVR; only one cryptographic
+implementation of Ed25519 is therefore needed on the Pledge.
+To enable such Pledges to authenticate, a Registrar MUST support digital signature algorithm Ed25519 and elliptic
+curve group X25519 (see {{RFC8446}}).
+
+Note that per {{Section 4.5.3 of RFC9147}} the cipher suite TLS_AES_128_CCM_8_SHA256 cannot be used unless specific
+measures are taken against packet forgery attacks.
+These measures are needed on both the DTLS 1.3 client and server.
+In the context of the cBRSKI protocol, the RECOMMENDED safeguard measure is to limit the number of records that can
+fail authentication to at most 2^7, as defined in {{Appendix B.3 of RFC9147}}.
+If that limit is reached, the DTLS connection is closed.
+This is a suitable measure because all cBRSKI and EST-coaps operations are relatively short-lived sessions that only require
+a few, or a few 10s of, DTLS records.
+
+A Pledge using DTLS 1.3 MUST implement at least one of the above cipher suites and MAY implement others.
 
 ### DTLS Client Certificates: IDevID authentication
 
@@ -2137,8 +2185,9 @@ The team includes the authors and: <contact initials="A." surname="Schellenbaum"
 
 -31:
     Move BRSKI/cBRSKI generic functions and RFC 8995 updates out of the cBRSKI-specific DTLS section (#352).
-    Better formulation on how RFC 8995 is updated and where.
+    Better formulation on how RFC 8995 and RFC 9148 are updated and where.
     Replace 'rt=brski.jp' discovery query by 'brski-jp=*' per #88 of draft-ietf-anima-constrained-join-proxy.
+    Added cipher suite details for DTLS 1.2 and 1.3.
     Bugfix to Pledge IDevID cert creation script (avoid 'faketime' process which had a conditional bug).
 
 -30:

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -99,6 +99,7 @@ informative:
   I-D.ietf-cbor-edn-literals:
   I-D.ietf-anima-brski-discovery:
   I-D.ietf-cose-cbor-encoded-cert:
+  I-D.ietf-uta-tls13-iot-profile:
   COSE-registry:
     title: "CBOR Object Signing and Encryption (COSE) registry group"
     target: "https://www.iana.org/assignments/cose/cose.xhtml"
@@ -303,8 +304,8 @@ be used is in a Pledge that uses a software platform where a DTLS 1.3 client is 
 device gets software-upgraded to support cBRSKI. For this reason, a Registrar MUST by default support both DTLS 1.3 and DTLS 1.2
 client connections. However, for security reasons the Registrar MAY be administratively configured to support only a particular DTLS version or higher.
 
-A Pledge that implements DTLS 1.3 MUST NOT additionally implement DTLS 1.2.
-This prevents a rogue Registrar from forcing the Pledge onto DTLS 1.2, reduces the DTLS code and attack surface on the
+A Pledge that implements DTLS 1.3 MUST NOT additionally support DTLS 1.2.
+This prevents a rogue Registrar from forcing the Pledge onto DTLS 1.2, reduces the DTLS code's attack surface on the
 constrained Pledge, and keeps more handshake metadata encrypted.
 
 An EST-coaps server {{RFC9148}}, if present as a separate CoAP endpoint from above Registrar, that implements this specification
@@ -344,14 +345,16 @@ curve group X25519 (see {{RFC8446}}).
 
 Note that per {{Section 4.5.3 of RFC9147}} the cipher suite TLS_AES_128_CCM_8_SHA256 cannot be used unless specific
 measures are taken against packet forgery attacks.
+See {{Section 20 of I-D.ietf-uta-tls13-iot-profile}} for a more detailed explanation of this topic.
 These measures are needed on both the DTLS 1.3 client and server.
 In the context of the cBRSKI protocol, the RECOMMENDED safeguard measure is to limit the number of records that can
 fail authentication to at most 2^7, as defined in {{Appendix B.3 of RFC9147}}.
-If that limit is reached, the DTLS connection is closed.
+If this measure is applied and the limit is reached, the DTLS connection is closed.
 This is a suitable measure because all cBRSKI and EST-coaps operations are relatively short-lived sessions that only require
 a few, or a few 10s of, DTLS records.
 
-A Pledge using DTLS 1.3 MUST implement at least one of the above cipher suites and MAY implement others.
+A Pledge using DTLS 1.3 MUST implement at least one of the above cipher suites supported by the Registrar and MAY
+implement multiple of these.
 
 ### DTLS Client Certificates: IDevID authentication
 


### PR DESCRIPTION
and related extra security requirements.
EST-coaps is now also updated with DTLS 1.3 cipher suites (which it didn't define yet).