### PR TITLE
Replace rt=brski.jp discovery by new target attribute brski-jp

### DIFF
--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -1086,7 +1086,7 @@ the Join Proxy's discovery response as the destination IP address for its subseq
 ### Examples {#pledge-discovery-examples}
 
 Below, a typical example is provided showing the Pledge's CoAP request and the Join Proxy's CoAP response.
-he Join Proxy responds from its link-local source address, which is not included in the discovery response payload.
+The Join Proxy responds from its link-local source address, which is not included in the discovery response payload.
 The Join Proxy has a dedicated UDP port 8485 open for DTLS connections of Pledges to be used for cBRSKI:
 
 ~~~~

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -1085,7 +1085,7 @@ the Join Proxy's discovery response as the destination IP address for its subseq
 
 ### Examples {#pledge-discovery-examples}
 
-Below, a typical example is provided showing the Pledge's CoAP request and the Join Proxy's CoAP response.
+Below, an example shows the Pledge's CoAP request and the Join Proxy's CoAP response.
 The Join Proxy responds from its link-local source address, which is not included in the discovery response payload.
 The Join Proxy has a dedicated UDP port 8485 open for DTLS connections of Pledges to be used for cBRSKI:
 

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -1073,79 +1073,60 @@ A Pledge that makes a voucher request to a Registrar that does not support that 
 Using CoAP discovery, a Pledge can discover a Join Proxy by sending a link-local multicast discovery message to the All CoAP Nodes address FF02::FD.
 Zero, one, or multiple Join Proxies may respond.
 The handling of multiple responses and absence of responses cases follow the guidelines of {{Section 4 of RFC8995}}.
-The discovery message is a CoAP GET request on the URI path `/.well-known/core` using a URI query "`rt=brski.jp`". This resource type ('`rt`') is defined
-in {{Section 8.1 of I-D.ietf-anima-constrained-join-proxy}}.
+The discovery message is a CoAP GET request on the URI path `/.well-known/core` using a URI query "`brski-jp=*`".
+This target attribute ('`brski-jp`') is defined for the specific purpose of discovering/advertising the join-port
+in {{Section 8.2 of I-D.ietf-anima-constrained-join-proxy}}.
 
 Responding Join Proxies return a CoRE Link Format document with one or more links.
 Each link indicates one CoAPS endpoint that offers cBRSKI Join Proxy functionality.
-Formally, each link indicates a CoAP root resource (`/`) tagged with the "`brski.jp`" type, hosted on a CoAPS endpoint.
 
 In case a Pledge selects a particular Join Proxy for cBRSKI onboarding, it MUST use the link-local source address of
 the Join Proxy's discovery response as the destination IP address for its subsequent onboarding attempt.
-This implies that the UTF-8 encoded link-local address literal that appears in the host subcomponent of each returned
-link is not used for determining the destination IP address of the onboarding attempt.
 
 ### Examples {#pledge-discovery-examples}
 
-Below, a typical example is provided showing the Pledge's CoAP request and the Join Proxy's CoAP response. The Join Proxy responds with a link-local
-source address, which is the same address as indicated in the URI-reference element ({{RFC6690}}) in the link in the discovery response payload.
-The Join Proxy has a dedicated UDP port 8485 open for DTLS connections of Pledges:
+Below, a typical example is provided showing the Pledge's CoAP request and the Join Proxy's CoAP response.
+he Join Proxy responds from its link-local source address, which is not included in the discovery response payload.
+The Join Proxy has a dedicated UDP port 8485 open for DTLS connections of Pledges to be used for cBRSKI:
 
 ~~~~
-  REQ: GET coap://[ff02::fd]/.well-known/core?rt=brski.jp
+  REQ: GET coap://[ff02::fd]/.well-known/core?brski-jp=*
 
   RES: 2.05 Content
     Content-Format: 40 (application/link-format)
     Payload:
-      <coaps://[fe80::c78:e3c4:58a0:a4ad]:8485>;rt=brski.jp
-~~~~
-
-Note that the Pledge would use the port number from the link in this response, but not the IPv6 literal in the host
-subcomponent (`[fe80::c78:e3c4:58a0:a4ad]`), as defined by the above discovery operation steps.
-
-The next example shows a Join Proxy that uses the default CoAPS port 5684 for DTLS connections of Pledges. In this case, the Join Proxy host
-is not using port 5684 for any other purposes, so it has the port available exclusively for accepting DTLS connections
-of Pledges.
-
-~~~~
-  REQ: GET coap://[ff02::fd]/.well-known/core?rt=brski.jp
-
-  RES: 2.05 Content
-    Content-Format: 40 (application/link-format)
-    Payload:
-      <coaps://[fe80::c78:e3c4:58a0:a4ad]>;rt=brski.jp
+      <>;brski-jp=8485
 ~~~~
 
 In the following example, two Join Proxies respond to the multicast query. The Join Proxies each use a slightly different CoRE Link Format
-'`rt`' value encoding. While the first encoding is more compact, both encodings are allowed per {{RFC6690}}. The Pledge may now select one of the
+target attribute value encoding. While the first encoding is more compact, both encodings are allowed per {{RFC6690}}. The Pledge may now select one of the
 two Join Proxies for initiating its DTLS connection.
 
 ~~~~
-  REQ: GET coap://[ff02::fd]/.well-known/core?rt=brski*
+  REQ: GET coap://[ff02::fd]/.well-known/core?brski-jp=*
 
   RES: 2.05 Content
     Content-Format: 40 (application/link-format)
     Payload:
-      <coaps://[fe80::c78:e3c4:58a0:a4ad]:8485>;rt=brski.jp
+      <>;brski-jp=8485
 
   RES: 2.05 Content
     Content-Format: 40 (application/link-format)
     Payload:
-      <coaps://[fe80::d359:3813:f382:3b23]:63245>;rt="brski.jp"
+      <>;brski-jp="63245"
 ~~~~
 
 In the final example, a single Join Proxy host responds with two distinct cBRSKI endpoints.
 The Pledge may now select one of the two CoAP endpoints for initiating its DTLS connection.
 
 ~~~~
-  REQ: GET coap://[ff02::fd]/.well-known/core?rt=brski*
+  REQ: GET coap://[ff02::fd]/.well-known/core?brski-jp=*
 
   RES: 2.05 Content
     Content-Format: 40 (application/link-format)
     Payload:
-      <coaps://[fe80::d359:3813:f382:3b23]:61616>;rt=brski.jp
-      <coaps://[fe80::d359:3813:f382:3b23]:61617>;rt=brski.jp;
-                                                  var="c509 v2"
+      <>;brski-jp=61616,
+      <>;brski-jp=61617;var="c509 v2"
 ~~~~
 
 The first endpoint on port 61616 supports only the cBRSKI protocol as defined by this document.
@@ -1154,10 +1135,11 @@ In this example, these variations/extensions are encoded using string values in 
 This information may be also encoded using other attributes defined by a future specification.
 
 A Pledge not aware of these variations can safely ignore these values, because the base cBRSKI protocol is supported
-by both endpoints, as indicated by the resource type ('`rt`').
-If however a Pledge is aware of these variations, it can select the endpoint with the variation it prefers, in case multiple options are discovered.
+by both endpoints, as indicated by the target attribute ('`brski-jp`').
+If however a Pledge is aware of these variations, it can select the endpoint with the variation it prefers,
+in case multiple options are discovered.
 The use of attributes with a single base resource type allows future extensibility of cBRSKI, and enables the
-Join Proxies to support cBRSKI variants that are unknown to them.
+Join Proxies to support (newer) cBRSKI variants that are unknown to them.
 
 
 ## Discovery Operations by a Join Proxy
@@ -1166,12 +1148,12 @@ A Join Proxy needs to discover a Registrar, either at the moment it needs to rel
 discovery as soon as it is requested to be enabled in a Join Proxy role. It may periodically redo this discovery, or periodically or on-demand check that the Registrar is still available
 in the network at the discovered IP address.
 
-As shown in the final example in {{pledge-discovery-examples}}, a Join Proxy can discover multiple Registrars in its network
+As shown in the final example in {{pledge-discovery-examples}}, a Join Proxy could discover multiple Registrars in its network
 and present these options to the Pledge.
 Each of these Registrars may support specific variations/extensions of cBRSKI - which may be defined in future documents.
 It is up to the administrator of the network how many Registrars are enabled.
 
-Further details on CoAP discovery of the Registrar by a Join Proxy are provided in {{Section 5.1.1 of I-D.ietf-anima-constrained-join-proxy}}.
+Further details on CoAP discovery of the Registrar by a Join Proxy are provided in {{Section 5.1 of I-D.ietf-anima-constrained-join-proxy}}.
 
 
 # Deployment-specific Discovery Considerations {#discovery-considerations}
@@ -2156,6 +2138,7 @@ The team includes the authors and: <contact initials="A." surname="Schellenbaum"
 -31:
     Move BRSKI/cBRSKI generic functions and RFC 8995 updates out of the cBRSKI-specific DTLS section (#352).
     Better formulation on how RFC 8995 is updated and where.
+    Replace 'rt=brski.jp' discovery query by 'brski-jp=*' per #88 of draft-ietf-anima-constrained-join-proxy.
     Bugfix to Pledge IDevID cert creation script (avoid 'faketime' process which had a conditional bug).
 
 -30:

--- a/constrained-voucher.mkd
+++ b/constrained-voucher.mkd
@@ -1087,7 +1087,7 @@ the Join Proxy's discovery response as the destination IP address for its subseq
 
 Below, an example shows the Pledge's CoAP request and the Join Proxy's CoAP response.
 The Join Proxy responds from its link-local source address, which is not included in the discovery response payload.
-The Join Proxy has a dedicated UDP port 8485 open for DTLS connections of Pledges to be used for cBRSKI:
+In this example, the Join Proxy has allocated the dedicated UDP port 8485 for DTLS connections. Traffic on that port from Pledges is used for cBRSKI:
 
 ~~~~
   REQ: GET coap://[ff02::fd]/.well-known/core?brski-jp=*


### PR DESCRIPTION
This is per [issue 88](https://github.com/anima-wg/constrained-join-proxy/issues/88) of draft-ietf-anima-constrained-join-proxy.